### PR TITLE
Enable pnpm package manager with corepack

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 - Node.js v20.x
 - corepack v0.20.0 or later
+- `corepack enable pnpm`
 
 ### Install dependencies
 


### PR DESCRIPTION
This pull request enables the use of the pnpm package manager with corepack. It adds the command `corepack enable pnpm` to the README.md file, allowing users to easily switch to using pnpm as their package manager. This update improves the flexibility and options available to developers using this project.