### PR TITLE
Fix badges and URLs for CI/CD workflows and code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # bot-worker
 
-[![Biome](https://github.com/NID-roid/bot-worker/actions/workflows/biome.yml/badge.svg)](https://github.com/NID-roid/bot-worker/actions/workflows/biome.yml)
-[![CI](https://github.com/NID-roid/bot-worker/actions/workflows/ci.yml/badge.svg)](https://github.com/NID-roid/bot-worker/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/NID-roid/bot-worker/actions/workflows/codeql.yml/badge.svg)](https://github.com/NID-roid/bot-worker/actions/workflows/codeql.yml)
-[![codecov](https://codecov.io/gh/NID-roid/bot-worker/graph/badge.svg?token=QZY0ET2KNU)](https://codecov.io/gh/NID-roid/bot-worker)
+[![Biome](https://github.com/NID-kt/bot-worker/actions/workflows/biome.yml/badge.svg)](https://github.com/NID-kt/bot-worker/actions/workflows/biome.yml)
+[![CI](https://github.com/NID-kt/bot-worker/actions/workflows/ci.yml/badge.svg)](https://github.com/NID-kt/bot-worker/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/NID-kt/bot-worker/actions/workflows/codeql.yml/badge.svg)](https://github.com/NID-kt/bot-worker/actions/workflows/codeql.yml)
+[![codecov](https://codecov.io/gh/NID-kt/bot-worker/graph/badge.svg?token=QZY0ET2KNU)](https://codecov.io/gh/NID-kt/bot-worker)
 
 ## Run bot-worker
 


### PR DESCRIPTION
This pull request fixes the badges and URLs for the CI/CD workflows and code coverage in the README.md file. The badges were pointing to the wrong repository, so this PR updates them to the correct repository (NID-kt/bot-worker).