### PR TITLE
Remove NODE_ENV from devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,8 +27,7 @@
 
   "remoteEnv": {
     "POSTGRES_URL": "postgresql://postgres:postgres@localhost:5432/postgres",
-    "AUDIT_LOG_WEBHOOK": "https://httpbin.org/status/200",
-    "NODE_ENV": "devs"
+    "AUDIT_LOG_WEBHOOK": "https://httpbin.org/status/200"
   }
 
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/.devcontainer/self-build/compose.yaml
+++ b/.devcontainer/self-build/compose.yaml
@@ -1,4 +1,3 @@
-
 services:
   app:
     build: 


### PR DESCRIPTION
This pull request removes the `NODE_ENV` variable from the `devcontainer.json` file. The `NODE_ENV` variable is no longer needed for development purposes.