### PR TITLE
Update CI workflow to ignore scripts during dependency installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Build
         run: pnpm build


### PR DESCRIPTION
This pull request updates the CI workflow to ignore scripts during dependency installation. Previously, the scripts were being executed during the installation process, which caused unnecessary overhead. By ignoring the scripts, the installation process becomes faster and more efficient.