### PR TITLE
Update SQL query to use LEFT JOIN for commands and emojis

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,8 @@ export const updateQueryCache = async (queryCache: QueryCache) => {
   queryCache.reactionAgentEmojis = reactionAgentEmojis.rows;
 
   const commands = await sql<Command>`
-    SELECT c.command, c.response, array_agg(e.value) as values
+    SELECT c.command, c.response,
+      COALESCE(array_agg(e.value) FILTER (WHERE e.value IS NOT NULL), '{}') as values
     FROM commands c
     LEFT JOIN commands_emojis ce ON c.id = ce."commandId"
     LEFT JOIN emojis e ON e.id = ce."emojiId"

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,8 +70,8 @@ export const updateQueryCache = async (queryCache: QueryCache) => {
   const commands = await sql<Command>`
     SELECT c.command, c.response, array_agg(e.value) as values
     FROM commands c
-    JOIN commands_emojis ce ON c.id = ce."commandId"
-    JOIN emojis e ON e.id = ce."emojiId"
+    LEFT JOIN commands_emojis ce ON c.id = ce."commandId"
+    LEFT JOIN emojis e ON e.id = ce."emojiId"
     GROUP BY c.id, c.command, c.response
     ORDER BY c.id ASC;
   `;


### PR DESCRIPTION
This pull request updates the SQL query in the `index.ts` file to use a LEFT JOIN instead of an INNER JOIN for the `commands_emojis` and `emojis` tables. This change ensures that all commands are included in the result, even if there are no corresponding emojis.